### PR TITLE
feat: 공통 API 응답 및 전역 예외 처리 추가

### DIFF
--- a/src/main/java/bank/p2pbank/global/common/ApplicationResponse.java
+++ b/src/main/java/bank/p2pbank/global/common/ApplicationResponse.java
@@ -1,0 +1,36 @@
+package bank.p2pbank.global.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+//공통 응답 클래스 - 성공 응답과 오류 응답을 구분하여 처리
+public record ApplicationResponse<T>(
+        LocalDateTime timestamp,
+        Integer code,
+        String message,
+        T data
+) {
+    public ApplicationResponse(BaseResponseCode responseCode, T data) {
+        this(LocalDateTime.now(), responseCode.getCode(), responseCode.getMessage(), data);
+    }
+
+    public static <T> ApplicationResponse<T> success(SuccessCode successCode, T data) {
+        return new ApplicationResponse<>(successCode, data);
+    }
+
+    public static ApplicationResponse<Void> success(SuccessCode successCode) {
+        return new ApplicationResponse<>(successCode, null);
+    }
+
+    public static ApplicationResponse<Void> error(ErrorCode errorCode) {
+        return new ApplicationResponse<>(errorCode, null);
+    }
+
+    public static ApplicationResponse<Void> error(ErrorCode errorCode, String customMessage) {
+        return new ApplicationResponse<>(new ErrorCode(errorCode.getHttpStatus(), errorCode.getCode(), customMessage), null);
+    }
+}

--- a/src/main/java/bank/p2pbank/global/common/ApplicationResponse.java
+++ b/src/main/java/bank/p2pbank/global/common/ApplicationResponse.java
@@ -1,5 +1,7 @@
 package bank.p2pbank.global.common;
 
+import bank.p2pbank.global.exception.ErrorCode;
+import bank.p2pbank.global.success.SuccessCode;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
@@ -27,10 +29,6 @@ public record ApplicationResponse<T>(
     }
 
     public static ApplicationResponse<Void> error(ErrorCode errorCode) {
-        return new ApplicationResponse<>(errorCode, null);
-    }
-
-    public static ApplicationResponse<Void> error(ErrorCode errorCode, String customMessage) {
-        return new ApplicationResponse<>(new ErrorCode(errorCode.getHttpStatus(), errorCode.getCode(), customMessage), null);
+        return new ApplicationResponse<>(LocalDateTime.now(), errorCode.getCode(), errorCode.getMessage(), null);
     }
 }

--- a/src/main/java/bank/p2pbank/global/common/BaseResponseCode.java
+++ b/src/main/java/bank/p2pbank/global/common/BaseResponseCode.java
@@ -1,0 +1,9 @@
+package bank.p2pbank.global.common;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseResponseCode {
+    HttpStatus getHttpStatus();
+    Integer getCode();
+    String getMessage();
+}

--- a/src/main/java/bank/p2pbank/global/exception/ApplicationException.java
+++ b/src/main/java/bank/p2pbank/global/exception/ApplicationException.java
@@ -1,0 +1,10 @@
+package bank.p2pbank.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApplicationException extends RuntimeException {
+    public ErrorCode errorCode;
+}

--- a/src/main/java/bank/p2pbank/global/exception/ErrorCode.java
+++ b/src/main/java/bank/p2pbank/global/exception/ErrorCode.java
@@ -1,0 +1,34 @@
+package bank.p2pbank.global.exception;
+
+import bank.p2pbank.global.common.BaseResponseCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@ToString
+public enum ErrorCode implements BaseResponseCode {
+    INTERNAL_SERVER_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, 2000, "예기치 못한 오류가 발생했습니다."),
+    NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, 2001, "존재하지 않는 리소스입니다."),
+    INVALID_VALUE_EXCEPTION(HttpStatus.BAD_REQUEST, 2002, "올바르지 않은 요청 값입니다."),
+    UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED, 2003, "권한이 없는 요청입니다."),
+    ALREADY_DELETE_EXCEPTION(HttpStatus.BAD_REQUEST, 2004, "이미 삭제된 리소스입니다."),
+    FORBIDDEN_EXCEPTION(HttpStatus.FORBIDDEN, 2005, "인가되지 않는 요청입니다."),
+    ALREADY_EXIST_EXCEPTION(HttpStatus.BAD_REQUEST, 2006, "이미 존재하는 리소스입니다."),
+    INVALID_SORT_EXCEPTION(HttpStatus.BAD_REQUEST, 2007, "올바르지 않은 정렬 값입니다."),
+
+    // 3000: Auth Error
+    WRONG_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, 3002, "유효하지 않은 토큰입니다."),
+    LOGOUT_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, 3003, "로그아웃된 토큰입니다"),
+    WRONG_TOKEN(HttpStatus.UNAUTHORIZED, 3004, "유효하지 않은 토큰입니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, Integer code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/bank/p2pbank/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/bank/p2pbank/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package bank.p2pbank.global.exception;
+
+import bank.p2pbank.global.common.ApplicationResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+
+//전역 예외 처리 핸들러
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApplicationException.class)
+    protected ResponseEntity<ApplicationResponse<Void>> handleApplicationException(ApplicationException e) {
+        log.error("ApplicationException: {}", e.getErrorCode());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(ApplicationResponse.error(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    protected ResponseEntity<ApplicationResponse<Void>> handleRuntimeException(RuntimeException e) {
+        log.error("Unexpected error: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApplicationResponse.error(ErrorCode.INTERNAL_SERVER_EXCEPTION));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApplicationResponse<Void>> methodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("Validation error: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApplicationResponse.error(ErrorCode.INVALID_VALUE_EXCEPTION));
+    }
+}

--- a/src/main/java/bank/p2pbank/global/success/SuccessCode.java
+++ b/src/main/java/bank/p2pbank/global/success/SuccessCode.java
@@ -1,0 +1,23 @@
+package bank.p2pbank.global.success;
+
+import bank.p2pbank.global.common.BaseResponseCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@ToString
+public enum SuccessCode implements BaseResponseCode {
+    SUCCESS(HttpStatus.OK, 1000, "정상적인 요청입니다."),
+    CREATED(HttpStatus.CREATED, 1001, "정상적으로 생성되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+
+    SuccessCode(HttpStatus httpStatus, Integer code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #7 

## 📝 작업 내용
공통 API 응답 및 전역 예외 처리 클래스 생성 및 구현

## 💬 구현하면서 고민했던 점
**응답 코드(ErrorCode)와 성공 코드(SuccessCode)를 분리**하면서도, 
**하나의 공통 응답 형식(ApplicationResponse)으로 처리**할 수 있도록 고민했습니다.

-> 이를 해결하기 위해 `BaseResponseCode` 인터페이스를 생성하고, 
   `ErrorCode`와 `SuccessCode`에서 이를 구현하도록 하였습니다.  
   이렇게 함으로써 `ApplicationResponse` 에서 두 코드를 공통적으로 사용할 수 있도록 하였습니다.

