### PR TITLE
feat: 회원가입 & 로그인 API, 통합 테스트 &  docker & redis 환경 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:21-slim
+ARG JAR_FILE=./build/libs/P2PBank-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["sh", "-c", "java -Duser.timezone=Asia/Seoul -jar /app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	//test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.testcontainers:junit-jupiter:1.19.0'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testImplementation 'org.testcontainers:testcontainers:1.19.0'
-	testImplementation 'org.testcontainers:mysql:1.19.0'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:mysql'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
@@ -63,6 +64,12 @@ dependencies {
 	//validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.testcontainers:testcontainers-bom:1.19.0"
+	}
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
 	//test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.testcontainers:junit-jupiter'
 	testImplementation 'org.testcontainers:mysql'

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,10 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.testcontainers:junit-jupiter:1.19.0'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'org.testcontainers:testcontainers:1.19.0'
+	testImplementation 'org.testcontainers:mysql:1.19.0'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
@@ -59,7 +62,7 @@ dependencies {
 
 	//validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -27,20 +27,20 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 
 	//querydsl
 	implementation 'com.querydsl:querydsl-apt:5.0.0'
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	implementation 'com.querydsl:querydsl-core:5.0.0'
-
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
-
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
@@ -53,6 +53,13 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// Json Type Parsing
+	implementation 'com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations'
+
+	//validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
 	//validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 dependencyManagement {

--- a/src/main/java/bank/p2pbank/P2PBankApplication.java
+++ b/src/main/java/bank/p2pbank/P2PBankApplication.java
@@ -10,6 +10,7 @@ public class P2PBankApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(P2PBankApplication.class, args);
+		System.out.println("P2PBank Server Start");
 	}
 
 }

--- a/src/main/java/bank/p2pbank/domain/user/controller/AuthController.java
+++ b/src/main/java/bank/p2pbank/domain/user/controller/AuthController.java
@@ -1,0 +1,11 @@
+package bank.p2pbank.domain.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+}

--- a/src/main/java/bank/p2pbank/domain/user/controller/AuthController.java
+++ b/src/main/java/bank/p2pbank/domain/user/controller/AuthController.java
@@ -1,6 +1,13 @@
 package bank.p2pbank.domain.user.controller;
 
+import bank.p2pbank.domain.user.dto.request.RegisterRequest;
+import bank.p2pbank.domain.user.service.AuthService;
+import bank.p2pbank.global.common.ApplicationResponse;
+import bank.p2pbank.global.success.SuccessCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,4 +15,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
 public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/register")
+    public ApplicationResponse<Void> register(@Valid @RequestBody RegisterRequest registerRequest) {
+        authService.register(registerRequest);
+
+        return ApplicationResponse.success(SuccessCode.CREATED);
+    }
 }

--- a/src/main/java/bank/p2pbank/domain/user/controller/UserController.java
+++ b/src/main/java/bank/p2pbank/domain/user/controller/UserController.java
@@ -1,0 +1,11 @@
+package bank.p2pbank.domain.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+public class UserController {
+}

--- a/src/main/java/bank/p2pbank/domain/user/dto/request/LoginRequest.java
+++ b/src/main/java/bank/p2pbank/domain/user/dto/request/LoginRequest.java
@@ -1,0 +1,15 @@
+package bank.p2pbank.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record LoginRequest(
+        @NotNull @Email
+        String email,
+
+        @NotNull @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+        String password
+) {
+}

--- a/src/main/java/bank/p2pbank/domain/user/dto/request/RegisterRequest.java
+++ b/src/main/java/bank/p2pbank/domain/user/dto/request/RegisterRequest.java
@@ -3,11 +3,12 @@ package bank.p2pbank.domain.user.dto.request;
 import bank.p2pbank.domain.user.enumerate.Role;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record RegisterRequest(
         @NotNull @Email
         String email,
-        @NotNull
+        @NotNull @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
         String password,
         @NotNull
         String name,

--- a/src/main/java/bank/p2pbank/domain/user/dto/request/RegisterRequest.java
+++ b/src/main/java/bank/p2pbank/domain/user/dto/request/RegisterRequest.java
@@ -1,0 +1,11 @@
+package bank.p2pbank.domain.user.dto.request;
+
+import bank.p2pbank.domain.user.enumerate.Role;
+
+public record RegisterRequest(
+        String email,
+        String password,
+        String name,
+        Role role
+) {
+}

--- a/src/main/java/bank/p2pbank/domain/user/dto/request/RegisterRequest.java
+++ b/src/main/java/bank/p2pbank/domain/user/dto/request/RegisterRequest.java
@@ -4,7 +4,9 @@ import bank.p2pbank.domain.user.enumerate.Role;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
+@Builder
 public record RegisterRequest(
         @NotNull @Email
         String email,

--- a/src/main/java/bank/p2pbank/domain/user/dto/request/RegisterRequest.java
+++ b/src/main/java/bank/p2pbank/domain/user/dto/request/RegisterRequest.java
@@ -1,11 +1,17 @@
 package bank.p2pbank.domain.user.dto.request;
 
 import bank.p2pbank.domain.user.enumerate.Role;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 
 public record RegisterRequest(
+        @NotNull @Email
         String email,
+        @NotNull
         String password,
+        @NotNull
         String name,
-        Role role
+        @NotNull
+        String role
 ) {
 }

--- a/src/main/java/bank/p2pbank/domain/user/entity/User.java
+++ b/src/main/java/bank/p2pbank/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package bank.p2pbank.domain.user.entity;
 
+import bank.p2pbank.domain.user.dto.request.RegisterRequest;
 import bank.p2pbank.domain.user.enumerate.Role;
 import bank.p2pbank.global.common.BaseTimeEntity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -34,10 +35,10 @@ public class User extends BaseTimeEntity {
     private Role role;
 
     @Builder
-    public User(String email, String password, String name) {
-        this.email = email;
-        this.password = password;
-        this.name = name;
-        this.role = Role.GENERAL;
+    public User(RegisterRequest registerRequest) {
+        this.email = registerRequest.email();
+        this.password = registerRequest.password();
+        this.name = registerRequest.name();
+        this.role = registerRequest.role();
     }
 }

--- a/src/main/java/bank/p2pbank/domain/user/entity/User.java
+++ b/src/main/java/bank/p2pbank/domain/user/entity/User.java
@@ -24,7 +24,7 @@ public class User extends BaseTimeEntity {
     private String email;
 
     @JsonIgnore //JSON 직렬화에서 제외한다
-    @Column(name = "password",nullable = false, columnDefinition = "varchar(255)")
+    @Column(name = "password", nullable = false, columnDefinition = "varchar(255)")
     private String password;
 
     @Column(name = "name", nullable = false, columnDefinition = "varchar(50)")
@@ -35,10 +35,10 @@ public class User extends BaseTimeEntity {
     private Role role;
 
     @Builder
-    public User(RegisterRequest registerRequest) {
-        this.email = registerRequest.email();
-        this.password = registerRequest.password();
-        this.name = registerRequest.name();
-        this.role = registerRequest.role();
+    public User(String email, String password, String name, Role role) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.role = role;
     }
 }

--- a/src/main/java/bank/p2pbank/domain/user/enumerate/Role.java
+++ b/src/main/java/bank/p2pbank/domain/user/enumerate/Role.java
@@ -1,5 +1,20 @@
 package bank.p2pbank.domain.user.enumerate;
 
+import bank.p2pbank.global.exception.ApplicationException;
+import bank.p2pbank.global.exception.ErrorCode;
+
+import java.util.Arrays;
+import java.util.Locale;
+
 public enum Role {
-    GENERAL, ADMIN
+    GENERAL, ADMIN;
+
+    public static Role of(String role) {
+        String upperRole = role.toUpperCase(Locale.ROOT);
+
+        return Arrays.stream(Role.values())
+                .filter(r -> r.name().equals(upperRole))
+                .findFirst()
+                .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_VALUE_EXCEPTION));
+    }
 }

--- a/src/main/java/bank/p2pbank/domain/user/repository/UserRepository.java
+++ b/src/main/java/bank/p2pbank/domain/user/repository/UserRepository.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
-@Repository
 public interface UserRepository extends JpaRepository<User,Long> {
     /**
      * email을 기준으로 사용자 찾는다

--- a/src/main/java/bank/p2pbank/domain/user/repository/UserRepository.java
+++ b/src/main/java/bank/p2pbank/domain/user/repository/UserRepository.java
@@ -14,5 +14,5 @@ public interface UserRepository extends JpaRepository<User,Long> {
      * @param role 역할
      * @return Optional<User></User></User>
      */
-    Optional<User> findUserByEmailAndRole(String email, Role role);
+    Optional<User> findUserByEmailAndRoleAndDeletedAtIsNull(String email, Role role);
 }

--- a/src/main/java/bank/p2pbank/domain/user/repository/UserRepository.java
+++ b/src/main/java/bank/p2pbank/domain/user/repository/UserRepository.java
@@ -9,10 +9,17 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User,Long> {
     /**
-     * email을 기준으로 사용자 찾는다
+     * email,role을 기준으로 사용자 찾는다
      * @param email 이메일
      * @param role 역할
      * @return Optional<User></User></User>
      */
     Optional<User> findUserByEmailAndRoleAndDeletedAtIsNull(String email, Role role);
+
+    /**
+     * email 기준으로 사용자 찾는다
+     * @param email 이메일
+     * @return Optional<User></User>
+     */
+    Optional<User> findUserByEmailAndDeletedAtIsNull(String email);
 }

--- a/src/main/java/bank/p2pbank/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/bank/p2pbank/domain/user/repository/UserRepositoryCustom.java
@@ -1,0 +1,4 @@
+package bank.p2pbank.domain.user.repository;
+
+public interface UserRepositoryCustom {
+}

--- a/src/main/java/bank/p2pbank/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/bank/p2pbank/domain/user/repository/UserRepositoryImpl.java
@@ -1,0 +1,9 @@
+package bank.p2pbank.domain.user.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepositoryCustom {
+}

--- a/src/main/java/bank/p2pbank/domain/user/service/AuthService.java
+++ b/src/main/java/bank/p2pbank/domain/user/service/AuthService.java
@@ -8,6 +8,7 @@ import bank.p2pbank.global.exception.ApplicationException;
 import bank.p2pbank.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class AuthService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public void register(RegisterRequest registerRequest) {
@@ -31,7 +33,7 @@ public class AuthService {
 
         User user = User.builder()
                 .email(registerRequest.email())
-                .password(registerRequest.password())
+                .password(passwordEncoder.encode(registerRequest.password()))
                 .name(registerRequest.name())
                 .role(role)
                 .build();

--- a/src/main/java/bank/p2pbank/domain/user/service/AuthService.java
+++ b/src/main/java/bank/p2pbank/domain/user/service/AuthService.java
@@ -1,0 +1,9 @@
+package bank.p2pbank.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+}

--- a/src/main/java/bank/p2pbank/domain/user/service/AuthService.java
+++ b/src/main/java/bank/p2pbank/domain/user/service/AuthService.java
@@ -1,9 +1,42 @@
 package bank.p2pbank.domain.user.service;
 
+import bank.p2pbank.domain.user.dto.request.RegisterRequest;
+import bank.p2pbank.domain.user.entity.User;
+import bank.p2pbank.domain.user.enumerate.Role;
+import bank.p2pbank.domain.user.repository.UserRepository;
+import bank.p2pbank.global.exception.ApplicationException;
+import bank.p2pbank.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void register(RegisterRequest registerRequest) {
+        Role role = Role.of(registerRequest.role());
+        Optional<User> exsitUser = userRepository.findUserByEmailAndRoleAndDeletedAtIsNull(registerRequest.email(), role);
+
+        if (exsitUser.isPresent()) {
+            log.warn("존재하는 사용자. email={}, role={}", registerRequest.email(), role);
+            throw new ApplicationException(ErrorCode.ALREADY_EXIST_EXCEPTION);
+        }
+
+        User user = User.builder()
+                .email(registerRequest.email())
+                .password(registerRequest.password())
+                .name(registerRequest.name())
+                .role(role)
+                .build();
+
+        userRepository.save(user);
+    }
+
 }

--- a/src/main/java/bank/p2pbank/domain/user/service/UserService.java
+++ b/src/main/java/bank/p2pbank/domain/user/service/UserService.java
@@ -1,0 +1,9 @@
+package bank.p2pbank.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+}

--- a/src/main/java/bank/p2pbank/global/common/BaseTimeEntity.java
+++ b/src/main/java/bank/p2pbank/global/common/BaseTimeEntity.java
@@ -3,12 +3,14 @@ package bank.p2pbank.global.common;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Getter
 @MappedSuperclass //JPA에 공통 엔티티 상속받아 사용, 실제 테이블이 생성되지 않고 하위 엔티티 테이블에서 적용
 @EntityListeners(AuditingEntityListener.class) //JPA Auduting 기능 활성화하여, @CreatedDate와 @LastModifiedDate 자동으로 동작
 public abstract class BaseTimeEntity {

--- a/src/main/java/bank/p2pbank/global/config/RedisConfig.java
+++ b/src/main/java/bank/p2pbank/global/config/RedisConfig.java
@@ -14,10 +14,10 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableRedisRepositories
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String host;
 
-    @Value("${spring.redis.port}")
+    @Value("${spring.data.redis.port}")
     private Integer port;
 
     @Bean

--- a/src/main/java/bank/p2pbank/global/config/RedisConfig.java
+++ b/src/main/java/bank/p2pbank/global/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package bank.p2pbank.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+//RedisTemplate 빈 등록
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private Integer port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/bank/p2pbank/global/config/SecurityConfig.java
+++ b/src/main/java/bank/p2pbank/global/config/SecurityConfig.java
@@ -1,16 +1,51 @@
 package bank.p2pbank.global.config;
 
+import bank.p2pbank.global.security.jwt.JwtAccessDeniedHandler;
+import bank.p2pbank.global.security.jwt.JwtAuthenticationEntryPoint;
+import bank.p2pbank.global.security.jwt.JwtFilter;
+import bank.p2pbank.global.security.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration //스프링의 설정 클래스임을 나타냄. 해당 어노테이션은 @Component와 같은 역할을 하며, 스프링이 이 클래스를 설정 클래스로 인식하여 빈들을 등록하도록 함
 @EnableWebSecurity //Spring Secuirty의 기본 설정을 활성화할 수 있음. 보안 필터 자동 적용
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final TokenProvider tokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    private static final String[] PUBLIC_API = {
+            "**/auth/register",
+            "**/auth/login"
+    };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PUBLIC_API).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder(); // BCrypt 해시 알고리즘을 이용하여 비밀번호 암호화

--- a/src/main/java/bank/p2pbank/global/config/SecurityConfig.java
+++ b/src/main/java/bank/p2pbank/global/config/SecurityConfig.java
@@ -25,8 +25,8 @@ public class SecurityConfig {
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     private static final String[] PUBLIC_API = {
-            "**/auth/register",
-            "**/auth/login"
+            "/api/v1/auth/register",
+            "/api/v1/auth/login"
     };
 
     @Bean

--- a/src/main/java/bank/p2pbank/global/exception/ErrorCode.java
+++ b/src/main/java/bank/p2pbank/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode implements BaseResponseCode {
     INVALID_SORT_EXCEPTION(HttpStatus.BAD_REQUEST, 2007, "올바르지 않은 정렬 값입니다."),
 
     // 3000: Auth Error
+    WRONG_PASSWORD_EXCEPTION(HttpStatus.BAD_REQUEST, 3002, "유효하지 않은 토큰입니다."),
     WRONG_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, 3002, "유효하지 않은 토큰입니다."),
     LOGOUT_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, 3003, "로그아웃된 토큰입니다"),
     WRONG_TOKEN(HttpStatus.UNAUTHORIZED, 3004, "유효하지 않은 토큰입니다.");

--- a/src/main/java/bank/p2pbank/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/bank/p2pbank/global/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RequiredArgsConstructor
 
 //전역 예외 처리 핸들러
+//ApplicationException을 잡아 ApplicationResponse.error()로 변환
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ApplicationException.class)

--- a/src/main/java/bank/p2pbank/global/security/jwt/TokenProvider.java
+++ b/src/main/java/bank/p2pbank/global/security/jwt/TokenProvider.java
@@ -130,7 +130,7 @@ public class TokenProvider {
     public Authentication getAuthentication(String token) {
         String email = getEmail(token);
         Role role = getRole(token);
-        User user = userRepository.findUserByEmailAndRole(email,role).orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION));
+        User user = userRepository.findUserByEmailAndRoleAndDeletedAtIsNull(email,role).orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION));
         PrincipalDetails principalDetails = new PrincipalDetails(user);
 
         return new UsernamePasswordAuthenticationToken(principalDetails, "", principalDetails.getAuthorities());

--- a/src/main/java/bank/p2pbank/global/util/redis/RedisClient.java
+++ b/src/main/java/bank/p2pbank/global/util/redis/RedisClient.java
@@ -1,0 +1,49 @@
+package bank.p2pbank.global.util.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+//Refresh Token 저장 및 관리
+@Component
+@RequiredArgsConstructor
+public class RedisClient {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    /**
+     * Redis에 값 삽입하는 메소드
+     * @param key - 삽입하고자 하는 데이터의 key
+     * @param value - 삽입하고자 하는 데이터의 value
+     * @param timeout - 삽입하고자 하는 데이터의 유효 시간
+     */
+    public void setValue(String key, String value, Long timeout) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.set(key, value, Duration.ofMinutes(timeout));
+    }
+
+    /**
+     * Redis에서 key값을 기반으로 value를 찾아서 반환하는 메소드
+     * @param key - value를 찾을 데이터의 key 값
+     * @return - 해당 데이터의 value 반환
+     */
+    public String getValue(String key) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+
+        values.get(key);
+
+        return values.get(key).toString();
+    }
+
+    /**
+     * Redis에서 key에 해당하는 데이터를 삭제하는 메소드
+     * @param key - 삭제할 데이터의 key를 의미
+     */
+    public void deleteValue(String key) {
+        redisTemplate.delete(key);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,9 @@
 spring:
+  data:
+    redis:
+      host: p2pbank-redis
+      port: 6379
+
   datasource:
     url: jdbc:mysql://localhost:3306/p2pBank?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root

--- a/src/test/java/bank/p2pbank/domain/user/controller/AuthControllerTest.java
+++ b/src/test/java/bank/p2pbank/domain/user/controller/AuthControllerTest.java
@@ -1,0 +1,93 @@
+package bank.p2pbank.domain.user.controller;
+
+import bank.p2pbank.domain.user.dto.request.RegisterRequest;
+import bank.p2pbank.domain.user.entity.User;
+import bank.p2pbank.domain.user.enumerate.Role;
+import bank.p2pbank.domain.user.repository.UserRepository;
+import bank.p2pbank.global.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+public class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Container
+    static MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0.30")
+            .withDatabaseName("testdb")
+            .withUsername("testuser")
+            .withPassword("testpass");
+
+    @DynamicPropertySource
+    static void setDatasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysqlContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", mysqlContainer::getUsername);
+        registry.add("spring.datasource.password", mysqlContainer::getPassword);
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 테스트")
+    public void register_success() throws Exception {
+        // given
+        RegisterRequest request = new RegisterRequest(
+                "test@example.com", "password123!", "test", "ADMIN"
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value("1001"))
+                .andExpect(jsonPath("$.message").value("정상적으로 생성되었습니다."));
+    }
+
+    @Test
+    @DisplayName("중복 회원가입 실패 테스트")
+    public void register_fail_alreadyExists() throws Exception {
+        // given
+        userRepository.save(User.builder()
+                .email("user@example.com")
+                .password("encodedPassword")
+                .name("홍길동")
+                .role(Role.GENERAL)
+                .build());
+
+        RegisterRequest request = new RegisterRequest(
+                "test@example.com", "password123!", "test", "ADMIN"
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.ALREADY_EXIST_EXCEPTION.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.ALREADY_EXIST_EXCEPTION.getMessage()));
+    }
+}

--- a/src/test/java/bank/p2pbank/domain/user/controller/AuthControllerTest.java
+++ b/src/test/java/bank/p2pbank/domain/user/controller/AuthControllerTest.java
@@ -4,6 +4,7 @@ import bank.p2pbank.domain.user.dto.request.RegisterRequest;
 import bank.p2pbank.domain.user.entity.User;
 import bank.p2pbank.domain.user.enumerate.Role;
 import bank.p2pbank.domain.user.repository.UserRepository;
+import bank.p2pbank.global.config.TestContainerConfig;
 import bank.p2pbank.global.exception.ErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
@@ -11,22 +12,23 @@ import org.junit.jupiter.api.DisplayName;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.junit.jupiter.Container;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-public class AuthControllerTest {
+@Testcontainers
+public class AuthControllerTest extends TestContainerConfig {
 
     @Autowired
     private MockMvc mockMvc;
@@ -38,16 +40,14 @@ public class AuthControllerTest {
     private UserRepository userRepository;
 
     @Container
-    static MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0.30")
-            .withDatabaseName("testdb")
-            .withUsername("testuser")
-            .withPassword("testpass");
+    @ServiceConnection
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.30");
 
     @DynamicPropertySource
-    static void setDatasourceProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", mysqlContainer::getJdbcUrl);
-        registry.add("spring.datasource.username", mysqlContainer::getUsername);
-        registry.add("spring.datasource.password", mysqlContainer::getPassword);
+    static void datasourceConfig(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
     }
 
     @Test

--- a/src/test/java/bank/p2pbank/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/bank/p2pbank/domain/user/service/AuthServiceTest.java
@@ -1,0 +1,75 @@
+package bank.p2pbank.domain.user.service;
+
+import bank.p2pbank.domain.user.dto.request.RegisterRequest;
+import bank.p2pbank.domain.user.entity.User;
+import bank.p2pbank.domain.user.repository.UserRepository;
+import bank.p2pbank.global.exception.ApplicationException;
+import bank.p2pbank.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+    @InjectMocks //테스트 대상인 AuthService 주입
+    private AuthService authService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("회원가입 성공 테스트")
+    void register_success() {
+        //given
+        RegisterRequest registerRequest = RegisterRequest.builder()
+                .email("test@test.com")
+                .name("서연")
+                .password("password123!")
+                .role("ADMIN")
+                .build();
+        given(userRepository.findUserByEmailAndRoleAndDeletedAtIsNull(any(), any()))
+                .willReturn(Optional.empty());
+        given(passwordEncoder.encode(any()))
+                .willReturn("encoded_password");
+
+        //when
+        authService.register(registerRequest);
+
+        // then
+        verify(userRepository, times(1)).save(any()); //save()가 한번 호풀 되어있는지 확인
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 사용자로 인한 회원가입 실패 테스트")
+    void register_fail_alreadyExists() {
+        // given
+        RegisterRequest request = new RegisterRequest("user@example.com", "password123!", "홍길동", "ADMIN");
+        given(userRepository.findUserByEmailAndRoleAndDeletedAtIsNull(any(), any()))
+                .willReturn(Optional.of(mock(User.class)));
+
+        // when & then
+        ApplicationException exception = assertThrows(ApplicationException.class, () ->
+                authService.register(request));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ALREADY_EXIST_EXCEPTION);
+        verify(userRepository, never()).save(any());
+    }
+
+}

--- a/src/test/java/bank/p2pbank/global/config/TestContainerConfig.java
+++ b/src/test/java/bank/p2pbank/global/config/TestContainerConfig.java
@@ -8,13 +8,13 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 public abstract class TestContainerConfig {
-    @Container
+    @Container //mysql 컨테이너 정의
     static MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0.30")
             .withDatabaseName("testdb")
             .withUsername("testuser")
             .withPassword("testpass");
 
-    @DynamicPropertySource
+    @DynamicPropertySource //컨테이너 가동시, 자동으로 springboot에 자동으로 주입
     static void setDatasourceProperties(DynamicPropertyRegistry registry) {
         registry.add("spring.datasource.url", mysqlContainer::getJdbcUrl);
         registry.add("spring.datasource.username", mysqlContainer::getUsername);

--- a/src/test/java/bank/p2pbank/global/config/TestContainerConfig.java
+++ b/src/test/java/bank/p2pbank/global/config/TestContainerConfig.java
@@ -1,0 +1,25 @@
+package bank.p2pbank.global.config;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public abstract class TestContainerConfig {
+    @Container
+    static MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0.30")
+            .withDatabaseName("testdb")
+            .withUsername("testuser")
+            .withPassword("testpass");
+
+    @DynamicPropertySource
+    static void setDatasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysqlContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", mysqlContainer::getUsername);
+        registry.add("spring.datasource.password", mysqlContainer::getPassword);
+        registry.add("spring.datasource.driver-class-name", mysqlContainer::getDriverClassName);
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #17 
- close #15 
- close #13 
- #6 

## 📝 작업 내용
- 회원가입 & 로그인 API
- 통합 테스트 환경 설정: TestContainerConfig 설정파일을 통하여, 통합 테스트시 mysql 주입할 수 있도록 설정
- docker 환경 설정: docker로 redis, mysql관리
- redis 환경 설정: refreshToken 유효시간 설정 관리하기 위해 설정

## 💬 구현하면서 알게된 점, 배운 점


<h1>Redis</h1>

**Redis (REmote DIctionary Server)**
는 오픈 소스 인메모리 데이터 저장소.
즉, 데이터를 
**메모리(RAM)**
에 저장하고, 저장된 데이터를 빠르게 읽고 쓸 수 있는 시스템

- 인메모리 저장소로 **빠르게 엑세스**
- key-value 구조
- String, List, Set, Sorted Set, Hash 등 다양한 자료구조 제공
- Redis Cluster를 통해 여러 서버에 데이터를 분산 저장 가능
- Key마다 TTL(만료 시간)을 설정 => 캐싱에 유리하다

<h2>Redis 주요 기능</h2>

<h3>캐싱 (Caching)</h3>
메모리 기반 특성 때문에 자주 사용되는 데이터에서 사용
- 만료시간(TTL)을 설정해 특정 시간 이후 자동 삭제 가능

예) 로그인한 사용자 정보 캐싱, API 응답 결과 캐싱 등

<h3>세션 관리 (Session Store)</h3>
서버가 세션을 관리하지 않고, Redis에 세션 정보 저장 가능
- 클러스터 환경에서도 모든 서버가 같은 세션을 조회 가능

<h3>메시지 큐 (Pub/Sub)</h3>
- publish/subscribe 기능 제공 => 실시간 알림 서비스 등에서 유용

<h3>분산 락 (Distributed Lock)</h3>
여러 서버가 동시에 같은 작업을 수행하지 않도록 락 걸기
- 예) 재고 감소 로직에서 중복 감소 방지

<h2>RefreshToken 저장공간을 Redis로 선택한 이유</h2>

- Redis에서 TTL설정 가능 => RefreshToken은 유효시간이 설정
- Redis는 데이터 유실 위험이 있지만 빠른 엑세스 특징인데, RefreshToken은 데이터 유실 되어도 재로그인을 통해서 가져올 수 있으므로 적합하다고 생각